### PR TITLE
Fix missing coverage issue

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,22 @@
+{
+"require": [
+      "@babel/register"
+    ],
+    "extension": [".vue"],
+    "include": [
+      "src/**/*.vue",
+      "src/**/*.js"
+    ],
+    "exclude": [
+      "src/test/js/**/*.spec.js",
+      "src/test/js/**/*.vue-spec.js",
+      "dist",
+      "target",
+      "node_modules",
+      "coverage",
+      ".babelcache",
+      "webpack.overrides.conf.js"
+    ],
+    "sourceMap": false,
+    "instrument": false
+  }

--- a/.nycrc
+++ b/.nycrc
@@ -10,6 +10,7 @@
     "exclude": [
       "src/test/js/**/*.spec.js",
       "src/test/js/**/*.vue-spec.js",
+      "test/**/*.js",
       "dist",
       "target",
       "node_modules",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.1
+### 12/17/2020 - [Diff](https://github.com/rei/vunit/compare/4.0.1...4.0.0) — [Docs](https://github.com/rei/vunit/blob/4.0.1/ReadMe.md)
+- Ensuring client uses .nycrc config from @rei/vunit. This fixes issue of no src files being reported during coverage run.
+- Include .vue, .js extensions
+- Exclude test/ directory
+
 ## 4.0.0
 ### 12/03/2020 - [Diff](https://github.com/rei/vunit/compare/4.0.0...3.0.1) — [Docs](https://github.com/rei/vunit/blob/4.0.0/ReadMe.md)
 - Switching from mocha-webpack to mochapack due to lack of maintenance now on mocha-webpack.

--- a/core.js
+++ b/core.js
@@ -11,7 +11,7 @@ const chokidar = require('chokidar');
  * @param {string}  conf.spec           Glob to mocha spec files.
  */
 
-const preProcess = conf => ({
+const preProcess = (conf) => ({
   watchedDirectories: conf.watch && conf.watch.length ? conf.watch.split(',') : [],
   webpackConfig: `${conf['webpack-config'] ? conf['webpack-config'] : path.join(__dirname, 'webpack.config.js')}`,
   specGlob: `${conf.spec ? conf.spec : ''}`,
@@ -21,6 +21,12 @@ const preProcess = conf => ({
 });
 
 module.exports.preProcess = preProcess;
+
+/**
+ * Get the full path to NYC config in order to point the client to .nycrc in @rei/vunit.
+ * @returns {string}
+ */
+const getPathToNYCConfig = () => path.join(__dirname, '.nycrc');
 
 module.exports.run = (conf) => {
   let watcher;
@@ -37,7 +43,9 @@ module.exports.run = (conf) => {
   console.log(`webpack config: ${conf['webpack-config'] ? conf['webpack-config'] : 'Using built-in config'}`);
   console.log(`specGlob: ${confPreprocessed.specGlob}`);
   console.log(`Coverage: ${confPreprocessed.coverage}`);
-  if(conf.require)console.log(`Required files: ${confPreprocessed.require}`);
+  console.log(`NYC Config: ${getPathToNYCConfig()}`);
+
+  if (conf.require)console.log(`Required files: ${confPreprocessed.require}`);
   console.log('--------------------------------');
 
   /**
@@ -50,6 +58,7 @@ module.exports.run = (conf) => {
       'BABEL_ENV=test',
       'NODE_ENV=test',
       'nyc',
+      `--nycrc-path=${getPathToNYCConfig()}`, // Use local .nycrc
       '--reporter=lcov',
       '--reporter=text',
       '--reporter=json-summary', // Required by @rei/cov-stats
@@ -66,10 +75,10 @@ module.exports.run = (conf) => {
 
     // Remove nyc and its options if not running coverage.
     if (!confPreprocessed.coverage) {
-      spawnCmd.splice(3, 5);
+      spawnCmd.splice(3, 6);
     }
 
-    if(conf.require) {
+    if (conf.require) {
       spawnCmd.push('--require');
       spawnCmd.push(confPreprocessed.require);
     }

--- a/core.js
+++ b/core.js
@@ -43,7 +43,10 @@ module.exports.run = (conf) => {
   console.log(`webpack config: ${conf['webpack-config'] ? conf['webpack-config'] : 'Using built-in config'}`);
   console.log(`specGlob: ${confPreprocessed.specGlob}`);
   console.log(`Coverage: ${confPreprocessed.coverage}`);
-  console.log(`NYC Config: ${getPathToNYCConfig()}`);
+
+  if (confPreprocessed.coverage) {
+    console.log(`NYC Config: ${getPathToNYCConfig()}`);
+  }
 
   if (conf.require)console.log(`Required files: ${confPreprocessed.require}`);
   console.log('--------------------------------');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/vunit",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rei/vunit",
   "description": "Write unit tests against your Vue components using mocha and vue-test-utils",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "author": "Alex Perkins <peripateticus.gh@gmail.com>",
   "repository": "https://github.com/rei/vunit",
   "license": "MIT",
@@ -46,13 +46,6 @@
     "vue-loader": "^15.9.0",
     "vue-template-compiler": "^2.6.11",
     "webpack-node-externals": "^1.6.0"
-  },
-  "nyc": {
-    "include": [
-      "src/**/*.(js|vue)"
-    ],
-    "instrument": false,
-    "sourceMap": false
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -1,63 +1,63 @@
 const assert = require('assert');
-const core = require('../core');
 const path = require('path');
+const core = require('../core');
 
 describe('preProcess', () => {
   it('should exist', () => {
     assert(typeof core.preProcess === 'function');
   });
 
-  describe( 'watch', function () {
+  describe('watch', () => {
     it('doesn\'t watch any dirs if none passed in', () => {
       assert.deepEqual(core.preProcess({
-        watch: undefined
-      }).watchedDirectories, [])
+        watch: undefined,
+      }).watchedDirectories, []);
     });
 
     it('should pass values through', () => {
       assert.deepEqual(core.preProcess({
-        watch: 'a,b'
-      }).watchedDirectories, ['a', 'b'])
+        watch: 'a,b',
+      }).watchedDirectories, ['a', 'b']);
     });
   });
 
-  describe( 'webpackConfig', function () {
+  describe('webpackConfig', () => {
     it('should pass passed in value through', () => {
       assert.equal(core.preProcess({
-        'webpack-config': 'a'
-      }).webpackConfig, 'a')
+        'webpack-config': 'a',
+      }).webpackConfig, 'a');
     });
 
     it('should default to local webpack config', () => {
       assert.equal(core.preProcess({
-        'webpack-config': undefined
-      }).webpackConfig, path.resolve(__dirname, '..', 'webpack.config.js'))
+        'webpack-config': undefined,
+      }).webpackConfig, path.resolve(__dirname, '..', 'webpack.config.js'));
     });
   });
 
-  describe( 'specGlob', function () {
+  describe('specGlob', () => {
     it('should pass passed in value through', () => {
       assert.equal(core.preProcess({
-        'spec': 'a'
+        spec: 'a',
       }).specGlob, 'a');
     });
 
     it('should default to empty', () => {
       assert.equal(core.preProcess({
-        'spec': undefined
+        spec: undefined,
       }).specGlob, '');
     });
   });
   describe('additional required file', () => {
     it('should pass in an additional required file if specified', () => {
       assert.equal(core.preProcess({
-        'require': './a'
-      }).require, './a')
+        require: './a',
+      }).require, './a');
     });
     it('should exclude the argument if empty', () => {
       assert.equal(core.preProcess({
-        'require': false
-      }).require, '')
-    })
-  })
+        require: false,
+      }).require, '');
+    });
+  });
 });


### PR DESCRIPTION
Currently, the client isn't picking up the needed NYC configuration for code coverage, this update will always pull in the .nycrc provided by `@rei/vunit`.